### PR TITLE
access status after evaluating response

### DIFF
--- a/samples/Worker/src/Worker.fs
+++ b/samples/Worker/src/Worker.fs
@@ -1,4 +1,6 @@
-﻿open Bix
+﻿module Worker
+
+open Bix
 open Bix.Router
 open Bix.Types
 open Bix.Handlers

--- a/src/Bix/Bix.fs
+++ b/src/Bix/Bix.fs
@@ -103,15 +103,12 @@ let getRouteMatch (ctx: HttpContext, baseUrl: string, notFound: HttpHandler, rou
         | Some NotFound -> notFound (fun _ -> Promise.lift None) ctx
 
 let handleRouteMatch (ctx: HttpContext) (bixResponse: JS.Promise<BixResponse option>) : JS.Promise<Response> =
-    let status = ctx.Response.Status
-
-    let contentType =
-        ctx.Response.Headers.ContentType |> Option.defaultValue "text/plain"
-
-    let options = [ Status status ]
-
     promise {
         let! response = bixResponse
+        let contentType =
+            ctx.Response.Headers.ContentType |> Option.defaultValue "text/plain"
+        let status = ctx.Response.Status
+        let options = [ Status status ]
 
         return
             match response with


### PR DESCRIPTION
This addresses https://github.com/AngelMunoz/Bix/issues/5 by moving the computation of status and content type until after the handler promise has completed, since that promise may have asynchronous mutations to the context that change these fields. 

I also added a module statement to the sample Worker to fix an error hit from a build (likely a stricter compiler error in more recent fsharp versions).